### PR TITLE
v1.2 Add Laravel Model Safety

### DIFF
--- a/src/Console/InstallsReactorCommand.php
+++ b/src/Console/InstallsReactorCommand.php
@@ -50,6 +50,9 @@ trait InstallsReactorCommand
         $this->installMiddlewareAfter('SubstituteBindings::class', '\App\Http\Middleware\HandleInertiaRequests::class');
         $this->installMiddlewareAfter('\App\Http\Middleware\HandleInertiaRequests::class', '\Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class');
 
+        // Providers...
+        copy(__DIR__.'/../../stubs/inertia-react/app/Providers/AppServiceProvider.php', app_path('Providers/AppServiceProvider.php'));
+
         copy(__DIR__.'/../../stubs/inertia-react/app/Http/Middleware/HandleInertiaRequests.php', app_path('Http/Middleware/HandleInertiaRequests.php'));
 
         // Views...

--- a/stubs/inertia-react/app/Providers/AppServiceProvider.php
+++ b/stubs/inertia-react/app/Providers/AppServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Eloquent\Model;
+
+class AppServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        Model::preventLazyLoading(!$this->app->isProduction());
+        Model::preventAccessingMissingAttributes();
+        Model::preventSilentlyDiscardingAttributes();
+    }
+}


### PR DESCRIPTION
This PR adds Laravel Safety Mechanisms. It will throw errors if you access a relationship without lazy loading, and some other goodies.